### PR TITLE
Removed gcc warning

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -283,13 +283,10 @@ void inv_shift_rows(uint8_t *state) {
 void sub_bytes(uint8_t *state) {
 
 	uint8_t i, j;
-	uint8_t row, col;
-
+	
 	for (i = 0; i < 4; i++) {
 		for (j = 0; j < Nb; j++) {
-			row = (state[Nb*i+j] & 0xf0) >> 4;
-			col = state[Nb*i+j] & 0x0f;
-			state[Nb*i+j] = s_box[16*row+col];
+			state[Nb*i+j] = s_box[state[Nb*i+j]];
 		}
 	}
 }
@@ -301,13 +298,10 @@ void sub_bytes(uint8_t *state) {
 void inv_sub_bytes(uint8_t *state) {
 
 	uint8_t i, j;
-	uint8_t row, col;
 
 	for (i = 0; i < 4; i++) {
 		for (j = 0; j < Nb; j++) {
-			row = (state[Nb*i+j] & 0xf0) >> 4;
-			col = state[Nb*i+j] & 0x0f;
-			state[Nb*i+j] = inv_s_box[16*row+col];
+			state[Nb*i+j] = inv_s_box[state[Nb*i+j]];
 		}
 	}
 }
@@ -322,7 +316,7 @@ void sub_word(uint8_t *w) {
 	uint8_t i;
 
 	for (i = 0; i < 4; i++) {
-		w[i] = s_box[16*((w[i] & 0xf0) >> 4) + (w[i] & 0x0f)];
+		w[i] = s_box[w[i]];
 	}
 }
 

--- a/aes.c
+++ b/aes.c
@@ -286,6 +286,9 @@ void sub_bytes(uint8_t *state) {
 	
 	for (i = 0; i < 4; i++) {
 		for (j = 0; j < Nb; j++) {
+			// s_box row: yyyy ----
+			// s_box col: ---- xxxx
+			// s_box[16*(yyyy) + xxxx] == s_box[yyyyxxxx]
 			state[Nb*i+j] = s_box[state[Nb*i+j]];
 		}
 	}

--- a/aes.c
+++ b/aes.c
@@ -155,7 +155,7 @@ uint8_t * Rcon(uint8_t i) {
 	} else if (i > 1) {
 		R[0] = 0x02;
 		i--;
-		while (i-1 > 0) {
+		while (i > 1) {
 			R[0] = gmult(R[0], 0x02);
 			i--;
 		}
@@ -350,7 +350,7 @@ void rot_word(uint8_t *w) {
 void aes_key_expansion(uint8_t *key, uint8_t *w) {
 
 	uint8_t tmp[4];
-	uint8_t i, j;
+	uint8_t i;
 	uint8_t len = Nb*(Nr+1);
 
 	for (i = 0; i < Nk; i++) {

--- a/aes.h
+++ b/aes.h
@@ -5,7 +5,7 @@
  *
  * Based on the document FIPS PUB 197
  */
-#include <stddef.h>
+
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/main.c
+++ b/main.c
@@ -6,11 +6,10 @@
  * Based on the document FIPS PUB 197
  */
 #include <stdio.h>
-#include <stdlib.h>
 
 #include "aes.h"
 
-int main(int argc, char *argv[]) {
+int main() {
 
 	uint8_t i;
 
@@ -125,5 +124,5 @@ int main(int argc, char *argv[]) {
 
 	free(w);
 
-	exit(0);
+	return 0;
 }


### PR DESCRIPTION
Hi.

Removed some unused variables and includes.

Also replaced stuff like this
`row = (state[Nb*i+j] & 0xf0) >> 4;`
`col = state[Nb*i+j] & 0x0f;`
`state[Nb*i+j] = inv_s_box[16*row+col];`
 with 
`state[Nb*i+j] = s_box[state[Nb*i+j]];`


I can make another pull requests with this things, if you approve it (maybe add const in const parameters?):

`uint8_t i;`
`for (i = 0; i < 4; i++) {`
`	w[i] = s_box[w[i]];`
`}`
replace with 
`for (uint8_t i = 0; i < 4; i++) {`
`	w[i] = s_box[w[i]];`
`}`